### PR TITLE
Fix ERR_CONNECTION_REFUSED for Chrome OS

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,2 +1,3 @@
 exports.port = process.env.PORT || 5001
+exports.host = process.env.HOST || 'localhost'
 exports.origin = process.env.ORIGIN || `http://localhost:${exports.port}`

--- a/server.js
+++ b/server.js
@@ -62,6 +62,6 @@ app.post('/contacts', bodyParser.json(), (req, res) => {
   }
 })
 
-app.listen(config.port, () => {
+app.listen(config.port, config.host, () => {
   console.log('Server listening on port %s, Ctrl+C to stop', config.port)
 })


### PR DESCRIPTION
When installed on Linux on Chrome OS, the server is not accessible
in Google Chrome out of the box.

To map ports automaticaly, host parameter needs to be passed to a
express app.listen() call.

Fixes #4